### PR TITLE
Fix version that recursive glob was implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ The code with `@` becomes more readable and more translatable between deep learn
 
 ## Globbing with `**`
 
-Recursive folder globbing is not easy in Python 2, even custom module [glob2](https://github.com/miracle2k/python-glob2) exists that overcomes this. Recursive flag is supported since Python 3.6:
+Recursive folder globbing is not easy in Python 2, even custom module [glob2](https://github.com/miracle2k/python-glob2) exists that overcomes this. Recursive flag is supported since Python 3.5:
 
 ```python
 import glob


### PR DESCRIPTION
Recursive glob was implemented in python 3.5:
https://docs.python.org/3/whatsnew/3.5.html#glob
https://docs.python.org/3.5/library/glob.html

