### PR TITLE
Less surprising code

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ For instance, measurement units are a common pain in scientific areas, `astropy`
 # Python 3
 from astropy import units as u
 @u.quantity_input()
-def frequency(speed: u.meter / u.s, wavelength: u.m) -> u.terahertz:
+def frequency(speed: u.meter / u.s, wavelength: u.nm) -> u.terahertz:
     return speed / wavelength
 
 frequency(speed=300_000 * u.km / u.s, wavelength=555 * u.nm)


### PR DESCRIPTION
The Astropy convention makes the original code look strange: in the return statement, a speed in m/s divided by a wavelength in meters should give a result in Hertz, not THz.
Now, the original code works fine (because only the units of the result are fully taken seriously), but the proposed change makes the code look more correct and thus raises fewer questions.