### PR TITLE
math.inf is float("inf"), which is really infinite

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ class SVC(BaseSVC):
 
 ```python
 # Python 3
-math.inf # 'largest' number
+math.inf # Infinite float
 math.nan # not a number
 
 max_quality = -math.inf  # no more magic initial values!


### PR DESCRIPTION
math.inf is not "the largest number" (which sounds like it's the maximum finite float, sys.float_info.max): it is instead precisely the representation of infinity as a float.