### PR TITLE
fix a wrong explanation about NLP in Chinese version

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -423,7 +423,7 @@ if a: # WRONG check for None
 
 ## 用于NLP的Unicode 
 
-*译者注：NLP，神经语言程序学 (Neuro-Linguistic Programming) *
+*译者注：NLP，自然语言处理 (Natural Language Processing) *
 
 ```python
 s = '您好'


### PR DESCRIPTION
Found a wrong explanation in Chinese version, NLP is not Neuro-Linguistic Programming, the right explanation is Natural Language Processing.